### PR TITLE
Idea: Automatically verify the hash of the caller upon import

### DIFF
--- a/selfhash/selfhash.py
+++ b/selfhash/selfhash.py
@@ -7,7 +7,9 @@
 
 import hashlib
 import getpass
+import inspect
 import sys
+
 
 class SelfHash:
     """Class for SelfHash"""
@@ -47,3 +49,13 @@ class SelfHash:
         else:
             print("FAIL: The source code may have been tampered with or the salt/passphrase is incorrect.")
             sys.exit()
+
+
+def _get_caller_file():
+    stack = inspect.stack()
+    caller_frame = stack[-1]
+    caller_file = caller_frame.filename
+    return caller_file
+
+# Automatically hash the caller
+SelfHash().hash(_get_caller_file())

--- a/verify_auto.py
+++ b/verify_auto.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python
+# Hash: 66640455e16c6e97d768a9462c8e7ea8b1bd91aa40fbccb37fbb406731af4bd6
+
+"""Script to verify the selfhash/selfhash.py module hash"""
+
+import selfhash


### PR DESCRIPTION
What do you think about simplifying the API to automatically verify the hash upon import?

This makes it so that people can simply `import selfhash` and know that their file is good.

The downside is it is not as explicit as a normal python module API, and maybe other things I'm not aware of.