### PR TITLE
Automatically verify the hash of the caller upon import

### DIFF
--- a/selfhash/__init__.py
+++ b/selfhash/__init__.py
@@ -3,4 +3,17 @@
 
 """SelfHash __init__.py"""
 
+import inspect
+
 from .selfhash import SelfHash
+
+
+def _get_caller_file():
+    stack = inspect.stack()
+    caller_frame = stack[-1]
+    caller_file = caller_frame.filename
+    return caller_file
+
+
+# Automatically hash the caller
+SelfHash().hash(_get_caller_file())

--- a/selfhash/__init__.py
+++ b/selfhash/__init__.py
@@ -16,4 +16,6 @@ def _get_caller_file():
 
 
 # Automatically hash the caller
-SelfHash().hash(_get_caller_file())
+_caller_file = _get_caller_file()
+if _caller_file != '<stdin>':
+    SelfHash().hash(_get_caller_file())

--- a/verify_auto.py
+++ b/verify_auto.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python
+# Hash: 0dc6f9324cdae350bbe56519f1e4cc26d709579744124e16070bf733d6128818
+
+"""Script to verify the selfhash/selfhash.py module hash"""
+
+import selfhash  # noqa: F401


### PR DESCRIPTION
Take 2. first PR got auto closed it seems.

This time I moved the stack inspection to `__init__.py`, and I fixed the 'imported but unused' linter error.