### PR TITLE
Avoid throwing chained exceptions

### DIFF
--- a/selfhash/selfhash.py
+++ b/selfhash/selfhash.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Hash: 09063288aa0912b98bba70932e28b7b9f592478d9225317d8d67c281689926c9
+# Hash: d758637770374a601330b7e5dc60215505a338702c6188b8563034c3e487ab2b
 
 # No password is set for this hash as it is used to verify the selfhash module code itself and can be checked against the github repo
 
@@ -20,6 +20,8 @@ class SelfHash:
 
     def hash(self, file):
         """Function that hashes the source code"""
+        fail = False
+
         with open(file, 'r', encoding="utf-8") as source_file:
             file_data = source_file.readlines()
 
@@ -28,6 +30,9 @@ class SelfHash:
         except IndexError:
             print("The '# Hash:' line was not found in the file.")
             print("Please add '# Hash: INSERT_HASH_HERE' at \nthe top of your python file and try again.")
+            fail = True
+
+        if fail:
             sys.exit(1)
 
         self.file_data_hash = ''.join([line for i, line in enumerate(file_data) if i != hash_line_index])
@@ -43,9 +48,12 @@ class SelfHash:
         if self.known_hash in ("Hash:", "INSERT_HASH_HERE"):
             print("The hash of the source code is not set yet.\nPlease run the script once and then replace INSERT_HASH_HERE with the hash.")
             print("Hash of the source code:\n", self.source_code_hash)
-            sys.exit()
+            fail = True
         elif self.known_hash == self.source_code_hash:
             print("\033[92mPASS\033[0m: The program is verified and true.")
         else:
             print("\033[91mFAIL\033[0m: The source code may have been tampered with or the salt/passphrase is incorrect.")
-            sys.exit()
+            fail = True
+
+        if fail:
+            sys.exit(1)


### PR DESCRIPTION
I noticed this while testing things in a Jupyter notebook.

If `selfhash` fails the first test of looking for `# Hash:`, it catches an `IndexError` and then calls `sys.exit(1)`. This causes a `SystemExit` exception to get raised, but it then gets chained to the `IndexError`. This leads to the error getting displayed first as an `IndexError` in `selfhash`, then the `SystemExit` is below it.

This patch makes the behavior of the `hash` API more consistent by always raising a `SystemExit` exception upon failure, instead of sometimes throwing a chained exception.

![image](https://github.com/ronaldstoner/selfhash-python/assets/9980/a0e06cbe-59ca-4076-aaf1-9ca1b46634de)